### PR TITLE
Carter solidity fixes

### DIFF
--- a/contracts/PaymentHub.sol
+++ b/contracts/PaymentHub.sol
@@ -76,13 +76,13 @@ contract PaymentHub {
     }
 
     // consider renaming to payForFriends
-    function transaction(address _payer, address[] memory _payedFor, int[] memory _amounts) public {
+    function transaction(address[] memory _payedFor, int[] memory _amounts) public {
         int total = 0;
         for (uint i = 0; i < _payedFor.length; i++) {
             userToBalance[_payedFor[i]] -= _amounts[i];
             total += _amounts[i];
         }
-        userToBalance[_payer] += total;
+        userToBalance[msg.sender] += total;
     }
 
 }


### PR DESCRIPTION
The pay friend function will now take an msg.value, from an input box, rather than an argument passed. This allows fake ether to go directly from one account to the other. closes #43 